### PR TITLE
Remove spaces, parens and numbers from prompts only when trailing

### DIFF
--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -2,6 +2,7 @@ import argparse
 import itertools
 import math
 import os
+import re
 from pathlib import Path
 from typing import Optional
 import subprocess
@@ -355,14 +356,13 @@ class DreamBoothDataset(Dataset):
         
         if self.image_captions_filename:
             filename = Path(path).stem
-            
-            pt=''.join([i for i in filename if not i.isdigit()])
-            pt=pt.replace("_"," ")
-            pt=pt.replace("(","")
-            pt=pt.replace(")","")
-            pt=pt.replace("-","")
-            pt=pt.replace("conceptimagedb","")  
-            
+
+            # Replace underscores for spaces
+            pt=filename.replace("_"," ")
+            pt=pt.replace("conceptimagedb","")
+            # Remove trailing spaces, parens and numbers (e.g. " (1)")
+            pt=re.sub(r' *[0-9()]*$', '', pt)
+       
             if args.external_captions:
               cptpth=os.path.join(args.captions_dir, filename+'.txt')
               if os.path.exists(cptpth):


### PR DESCRIPTION
Initially reported here https://github.com/TheLastBen/fast-stable-diffusion/issues/1174#issuecomment-1366085743

This keeps dashes, for things words like `x-men`, `t-shirt`, or wanting a trigger like `wa-vy` or `mdjrny-v4 style` (real high profile examples).
It also preserves numbers unless they are at the end. For prompts like `analog style 1970's bar` or, again, `mdjrny-v4 style`

I see absolutely no downside to this over the current state, except for people expecting those to get trimmed, which I don't see as being frequent or useful. The current solution also leaves dup spaces when wiping numbers, dashes, etc.