### PR TITLE
Don't use filename on external captions (TI)

### DIFF
--- a/examples/dreambooth/train_dreambooth_rnpd_sdxl_TI.py
+++ b/examples/dreambooth/train_dreambooth_rnpd_sdxl_TI.py
@@ -407,7 +407,7 @@ class DreamBoothDataset(Dataset):
               cptpth=os.path.join(args.captions_dir, filename+'.txt')
               if os.path.exists(cptpth):
                 with open(cptpth, "r") as f:
-                    instance_prompt=pt+' '+f.read()
+                    instance_prompt=f.read()
               else:
                 instance_prompt=pt
             else:


### PR DESCRIPTION
Consistent with [train_dreambooth_rnpd_sdxl_lora.py](https://github.com/TheLastBen/diffusers/blob/b016ec6cf4ca3f850fdc145faffcb79174865d6f/examples/dreambooth/train_dreambooth_rnpd_sdxl_lora.py#L501C29-L501C29)